### PR TITLE
Using .map shows significant reduction in time

### DIFF
--- a/date-parse/date-parse.py
+++ b/date-parse/date-parse.py
@@ -19,6 +19,11 @@ def lookup(s):
     dates = {date:pd.to_datetime(date) for date in s.unique()}
     return s.apply(lambda v: dates[v])
 
+def lookup2(s):
+	'''uses .map() to apply changes'''
+	dates = {date:pd.to_datetime(date) for date in s.unique()}
+	return s.map(dates)
+	
 s = pd.Series(['01-31-2012']*100000)
 
 timing('to_datetime', lambda: pd.to_datetime(s))
@@ -26,3 +31,4 @@ timing('dateutil', lambda: s.apply(dateutil.parser.parse))
 timing('strptime', lambda: s.apply(lambda v: datetime.datetime.strptime(v, '%m-%d-%Y')))
 timing('manual', lambda: s.apply(lambda v: datetime.datetime(int(v[6:10]), int(v[0:2]), int(v[3:5]))))
 timing('lookup', lambda: lookup(s))
+timing('lookup', lambda: lookup2(s))


### PR DESCRIPTION
lookup2 function uses .map function instead of apply. For the same series, s, these were the benchmarks:

In [132]: %timeit lookup(s)
10 loops, best of 3: 36.2 ms per loop

In [133]: %timeit lookup2(s)
100 loops, best of 3: 7.05 ms per loop
